### PR TITLE
export returned type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ interface MakeEtaOptions {
   ignoreSameProgress?: boolean,
 }
 
-interface ETAInstance {
+export interface ETAInstance {
   start(): void
 
   reset(): void


### PR DESCRIPTION
Generally, people export all types of values that are returned by functions (on the top-level).

I have a small piece of code like so:
```ts
let laterDefined: ETAInstance | undefined = undefined;
laterDefined = makeEta({ max: 100 });
```

But as the `ETAInstance` is not exported I can't write the code above and need `any` to make it (unsafely) work.

Hope that makes sense. Great module, thanks!